### PR TITLE
Make fixed sidebar scrollable

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -677,6 +677,10 @@ a:hover tt, a:hover code {
     div.sphinxsidebar {
         position: fixed;
         margin-left: 0;
+        top: 0;
+        bottom: 0;
+        overflow-x: hidden;
+        overflow-y: scroll;
     }
 }
 {%- endif %}


### PR DESCRIPTION
Resolves inaccessible fixed sidebar content when the content overflows.

See stackoverflow answer https://stackoverflow.com/questions/16094785/have-a-fixed-position-div-that-needs-to-scroll-if-content-overflows for the inspiration.